### PR TITLE
Change test to only look at a tag instead of entire div

### DIFF
--- a/specs/courses-spec.js
+++ b/specs/courses-spec.js
@@ -69,7 +69,7 @@ describe('The Example App - Courses', () => {
     it('orders courses by creation date', () => {
       cy.visit('/courses')
 
-      cy.get('.grid-list .grid-list__item .course-card__title')
+      cy.get('.grid-list .grid-list__item .course-card__title a')
         .then(($items) => {
           const titles = Cypress._.map($items, ($item) => $item.innerText)
           const posHowTo = titles.findIndex((title) => title === 'How the example app is built')


### PR DESCRIPTION
I want to make this check more specific by targeting the a-tag instead of the entire title tag. I have a span tag in there on the course cards that screw it up otherwise.